### PR TITLE
inets: proper stop for httpc_handler keep-alive queue failure

### DIFF
--- a/lib/inets/src/http_client/httpc_handler.erl
+++ b/lib/inets/src/http_client/httpc_handler.erl
@@ -1332,7 +1332,7 @@ handle_keep_alive_queue(#state{status       = keep_alive,
 					     Session, <<>>,
 					     State#state{keep_alive = KeepAlive});
 			{error, Reason} ->
-			    {stop, shutdown, {keepalive_failed, Reason}, State}
+			    {stop, {shutdown, {keepalive_failed, Reason}}, State}
 		    end
 	    end
     end.


### PR DESCRIPTION
httpc_handler should respond with proper {stop, Reason, State}
message when sending request from keep-alive queue fails
