### PR TITLE
inets: cancel for handler with no requests

### DIFF
--- a/lib/inets/src/http_client/httpc_handler.erl
+++ b/lib/inets/src/http_client/httpc_handler.erl
@@ -420,6 +420,16 @@ handle_cast({cancel, RequestId},
                      {profile, ProfileName},
                      {canceled,   Canceled}]),
     {noreply, State#state{canceled = [RequestId | Canceled]}};
+handle_cast({cancel, RequestId},
+            #state{profile_name = ProfileName,
+                   request      = undefined,
+                   canceled     = Canceled} = State) ->
+    ?hcrv("cancel", [{request_id, RequestId},
+                     {curr_req_id, undefined},
+                     {profile, ProfileName},
+                     {canceled,   Canceled}]),
+    {noreply, State#state{canceled = [RequestId | Canceled]}};
+
 
 handle_cast(stream_next, #state{session = Session} = State) ->
     activate_once(Session), 


### PR DESCRIPTION
httpc_handler should react properly to cancel requests even
when the request to be cancelled was already finished
but httpc_manager did not get notified about that yet
