### PR TITLE
outdated request id to cancel should not be stored in handler state

### DIFF
--- a/lib/inets/src/http_client/httpc_handler.erl
+++ b/lib/inets/src/http_client/httpc_handler.erl
@@ -428,7 +428,7 @@ handle_cast({cancel, RequestId},
                      {curr_req_id, undefined},
                      {profile, ProfileName},
                      {canceled,   Canceled}]),
-    {noreply, State#state{canceled = [RequestId | Canceled]}};
+    {noreply, State};
 
 
 handle_cast(stream_next, #state{session = Session} = State) ->


### PR DESCRIPTION
due to Ingela's comment, otherwise we could have a minor "memory leak"
