### PR TITLE
inets: Forward connection errors with https proxy

### DIFF
--- a/lib/inets/src/http_client/httpc_handler.erl
+++ b/lib/inets/src/http_client/httpc_handler.erl
@@ -1814,13 +1814,13 @@ host_header(_, URI) ->
 tls_upgrade(#state{status = 
 		       {ssl_tunnel, 
 			#request{settings = 
-				     #http_options{ssl = {_, TLSOptions} = SocketType}} = Request},
+				     #http_options{ssl = {_, TLSOptions} = SocketType},
+				     address = Address} = Request},
 		   session = #session{socket = TCPSocket} = Session0,
 		   options = Options} = State) ->
 
     case ssl:connect(TCPSocket, TLSOptions) of
 	{ok, TLSSocket} ->
-	    Address = Request#request.address,
 	    ClientClose = httpc_request:is_client_closing(Request#request.headers),
 	    SessionType = httpc_manager:session_type(Options),
 	    Session = Session0#session{
@@ -1841,7 +1841,11 @@ tls_upgrade(#state{status =
 				   status = new
 				  },
 	    {noreply, activate_request_timeout(NewState)};
-	{error, _Reason} ->
+	{error, Reason} ->
+	    Error = httpc_response:error(Request, {failed_connect,
+						   [{to_address, Address},
+						    {tls, TLSOptions, Reason}]}),
+	    maybe_send_answer(Request, Error, State),
 	    {stop, normal, State#state{request = Request}}
     end.
 


### PR DESCRIPTION
httpc should return meaningful error reason disregarding whether
it is being used with http proxy or not
