### PR TITLE
inets: scheme validation fun for http_uri

### DIFF
--- a/lib/inets/doc/src/http_uri.xml
+++ b/lib/inets/doc/src/http_uri.xml
@@ -111,6 +111,16 @@ query()     = string()
 	a scheme not found in the scheme defaults) a port number must be 
 	provided or else the parsing will fail. </p>
 
+
+        <p>Scheme validation fun is to be defined as follows:
+
+	    <code>
+fun(SchemeStr :: string()) ->
+	valid |	{error, Reason :: term()}.
+	    </code>
+
+        It is called before scheme string gets converted into scheme atom and
+        thus possible atom leak could be prevented</p>
         <marker id="encode"></marker>
       </desc>
     </func>

--- a/lib/inets/src/http_lib/http_uri.erl
+++ b/lib/inets/src/http_lib/http_uri.erl
@@ -137,14 +137,31 @@ parse_scheme(AbsURI, Opts) ->
 	{error, no_scheme} ->
 	    {error, no_scheme};
 	{SchemeStr, Rest} ->
-	    Scheme = list_to_atom(http_util:to_lower(SchemeStr)),
-	    SchemeDefaults = which_scheme_defaults(Opts), 
-	    case lists:keysearch(Scheme, 1, SchemeDefaults) of
-		{value, {Scheme, DefaultPort}} ->
-		    {Scheme, DefaultPort, Rest};
-		false ->
-		    {Scheme, no_default_port, Rest}
+	    case extract_scheme(SchemeStr, Opts) of
+		{error, Error} ->
+		    {error, Error};
+		{ok, Scheme} ->
+		    SchemeDefaults = which_scheme_defaults(Opts),
+		    case lists:keysearch(Scheme, 1, SchemeDefaults) of
+			{value, {Scheme, DefaultPort}} ->
+			    {Scheme, DefaultPort, Rest};
+			false ->
+			    {Scheme, no_default_port, Rest}
+		    end
 	    end
+    end.
+
+extract_scheme(Str, Opts) ->
+    case lists:keysearch(scheme_validation_fun, 1, Opts) of
+	{value, {scheme_validation_fun, Fun}} when is_function(Fun) ->
+	    case Fun(Str) of
+		valid ->
+		    {ok, list_to_atom(http_util:to_lower(Str))};
+		{error, Error} ->
+		    {error, Error}
+	    end;
+	_ ->
+	    {ok, list_to_atom(http_util:to_lower(Str))}
     end.
 
 parse_uri_rest(Scheme, DefaultPort, "//" ++ URIPart, Opts) ->

--- a/lib/inets/test/uri_SUITE.erl
+++ b/lib/inets/test/uri_SUITE.erl
@@ -47,7 +47,8 @@ all() ->
      scheme,
      queries,
      escaped,
-     hexed_query
+     hexed_query,
+     scheme_validation
     ].
 
 %%--------------------------------------------------------------------
@@ -136,6 +137,26 @@ hexed_query(Config) when is_list(Config) ->
     verify_uri(URI1, Verify1),
     verify_uri(URI2, Verify2),
     verify_uri(URI3, Verify3).
+
+scheme_validation(Config) when is_list(Config) ->
+    {ok, {http,[],"localhost",80,"/",""}} =
+	http_uri:parse("http://localhost#fragment"),
+
+    ValidationFun =
+	fun("http") -> valid;
+	   (_) -> {error, bad_scheme}
+	end,
+
+    {ok, {http,[],"localhost",80,"/",""}} =
+	http_uri:parse("http://localhost#fragment",
+		       [{scheme_validation_fun, ValidationFun}]),
+    {error, bad_scheme} =
+	http_uri:parse("https://localhost#fragment",
+		       [{scheme_validation_fun, ValidationFun}]),
+    %% non-fun scheme_validation_fun works as no option passed
+    {ok, {https,[],"localhost",443,"/",""}} =
+	http_uri:parse("https://localhost#fragment",
+		       [{scheme_validation_fun, none}]).
 
 
 %%--------------------------------------------------------------------


### PR DESCRIPTION
http_uri:parse_scheme function should allow checking
scheme of URIs otherwise it could be easily abused to
reach limit number of atoms in the VM
