### PR TITLE
ssl: option to override TLS record layer version

### DIFF
--- a/lib/ssl/doc/src/ssl.xml
+++ b/lib/ssl/doc/src/ssl.xml
@@ -393,6 +393,13 @@ fun(srp, Username :: string(), UserState :: term()) ->
         Indication extension will be sent if possible, this option may also be
         used to disable that behavior.</p>
       </item>
+      <tag>record_layer_version</tag>
+      <item>
+        <p>This option can be used for backwards compatibility with older
+        servers as it is specified in section 1 of Appendix E in RFC 5246.</p>
+        <p>It provides a way to specify record layer version number different
+        from the highest protocol version which is used by default.</p>
+      </item>
     </taglist>
    </section>
 

--- a/lib/ssl/src/ssl_internal.hrl
+++ b/lib/ssl/src/ssl_internal.hrl
@@ -75,6 +75,7 @@
 -record(ssl_options, {
 	  protocol    :: tls | dtls,
 	  versions    :: ['tlsv1.2' | 'tlsv1.1' | tlsv1 | sslv3] | ['dtlsv1.2' | dtlsv1],
+	  record_layer_version :: undefined | 'tlsv1.2' | 'tlsv1.1' | tlsv1 | sslv3,
 	  verify      :: verify_none | verify_peer,
 	  verify_fun,  %%:: fun(CertVerifyErrors::term()) -> boolean(),
 	  fail_if_no_peer_cert ::  boolean(),

--- a/lib/ssl/src/tls_connection.erl
+++ b/lib/ssl/src/tls_connection.erl
@@ -185,7 +185,7 @@ hello(start, #state{host = Host, port = Port, role = client,
     Hello = tls_handshake:client_hello(Host, Port, ConnectionStates0, SslOpts,
 				       Cache, CacheCb, Renegotiation, Cert),
     
-    Version = Hello#client_hello.client_version,
+    Version = Hello#client_hello.record_layer_version,
     Handshake0 = ssl_handshake:init_handshake_history(),
     {BinMsg, ConnectionStates, Handshake} =
         encode_handshake(Hello, Version, ConnectionStates0, Handshake0),

--- a/lib/ssl/src/tls_handshake.erl
+++ b/lib/ssl/src/tls_handshake.erl
@@ -45,10 +45,12 @@
 %%--------------------------------------------------------------------
 client_hello(Host, Port, ConnectionStates,
 	     #ssl_options{versions = Versions,
+			  record_layer_version = OptsRecordVersion,
 			  ciphers = UserSuites
 			 } = SslOpts,
 	     Cache, CacheCb, Renegotiation, OwnCert) ->
     Version = tls_record:highest_protocol_version(Versions),
+    RecordLayerVersion = record_layer_version(Version, OptsRecordVersion),
     Pending = ssl_record:pending_connection_state(ConnectionStates, read),
     SecParams = Pending#connection_state.security_parameters,
     CipherSuites = ssl_handshake:available_suites(UserSuites, Version),
@@ -60,6 +62,7 @@ client_hello(Host, Port, ConnectionStates,
 
     #client_hello{session_id = Id,
 		  client_version = Version,
+		  record_layer_version = RecordLayerVersion,
 		  cipher_suites = ssl_handshake:cipher_suites(CipherSuites, Renegotiation),
 		  compression_methods = ssl_record:compressions(),
 		  random = SecParams#security_parameters.client_random,
@@ -240,3 +243,7 @@ handle_server_hello_extensions(Version, SessionId, Random, CipherSuite,
 	    {Version, SessionId, ConnectionStates, Protocol}
     end.
 
+record_layer_version(HighestVersion, undefined) ->
+    HighestVersion;
+record_layer_version(_, OptsVersion) ->
+    OptsVersion.

--- a/lib/ssl/src/tls_handshake.hrl
+++ b/lib/ssl/src/tls_handshake.hrl
@@ -29,6 +29,7 @@
 
 -record(client_hello, {
 	  client_version,
+	  record_layer_version,
 	  random,             
 	  session_id,          % opaque SessionID<0..32>
 	  cipher_suites,       % cipher_suites<2..2^16-1>


### PR DESCRIPTION
ssl application should allow override record layer
version used when sending client hello message as
a way to be more backwards compatible with older
servers
