### PR TITLE
Quick hack for header `host` position

### DIFF
--- a/lib/inets/src/http_lib/http_internal.hrl
+++ b/lib/inets/src/http_lib/http_internal.hrl
@@ -89,7 +89,6 @@
  	  authorization,
  	  expect, 
  	  from,
- 	  host,
  	  'if-match',
  	  'if-modified-since',
  	  'if-none-match',
@@ -112,7 +111,8 @@
  	  'content-type',
 	  expires,
  	  'last-modified',
-	  other=[]        % list() - Key/Value list with other headers
+	  other=[],       % list() - Key/Value list with other headers
+ 	  host
 	 }).
 
 -endif. % -ifdef(http_internal_hrl).


### PR DESCRIPTION
Forcing position of host header by placing it last in headers record, which makes host a first value in list of headers after left fold.
https://tools.ietf.org/html/rfc7230#section-5.4 paragraph 3
